### PR TITLE
Resolves HELIO-3088 monthly has too many records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: ruby
 cache: bundler
 sudo: required
 bundler_args: --without production
-before_install:
-  - gem update --system
-  - gem install bundler --pre
 before_script:
   - bin/bundle exec bin/setup
 rvm:

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -7,11 +7,23 @@ class ProgramsController < ApplicationController
 
   def show; end
 
-  def run
+  def run # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
     case params[:id]
     when 'assemble_marc_files'
-      AssembleMarcFiles.run
+      options = {}
+      options[:skip_catalog_sync] = true if assemble_marc_files_params[:skip_catalog_sync]
+      options[:reset_catalog_marcs] = true if assemble_marc_files_params[:reset_catalog_marcs]
+      options[:reset_umpebc_marcs] = true if assemble_marc_files_params[:reset_umpebc_marcs]
+      options[:reset_umpebc_kbarts] = true if assemble_marc_files_params[:reset_umpebc_kbarts]
+      options[:reset_upload_checksums] = true if assemble_marc_files_params[:reset_upload_checksums]
+      AssembleMarcFiles.run(options)
     end
     render :show
   end
+
+  private
+
+    def assemble_marc_files_params
+      params.permit(:utf8, :commit, :id, :skip_catalog_sync, :reset_catalog_marcs, :reset_umpebc_marcs, :reset_umpebc_kbarts, :reset_upload_checksums)
+    end
 end

--- a/app/controllers/umpebc_marcs_controller.rb
+++ b/app/controllers/umpebc_marcs_controller.rb
@@ -58,7 +58,7 @@ class UmpebcMarcsController < ApplicationController
     end
 
     def umpebc_marc_params
-      params.require(:umpebc_marc).permit(:doi, :mrc)
+      params.require(:umpebc_marc).permit(:doi, :year)
     end
 
     def filtering_params(params)

--- a/app/modules/lib_ptg_box/unmarshaller/sub_folder.rb
+++ b/app/modules/lib_ptg_box/unmarshaller/sub_folder.rb
@@ -34,8 +34,10 @@ module LibPtgBox
         @upload_folder ||= begin
           f = Ftp::Folder.null_folder
           folders.each do |folder|
-            next if /cataloging/i.match?(folder.name)
-            next unless /marc/i.match?(folder.name)
+            # TODO: Uncomment after bug fix
+            # next if /cataloging/i.match?(folder.name)
+            # next unless /marc/i.match?(folder.name)
+            next unless /dev/i.match?(folder.name)
 
             f = folder
             break

--- a/app/programs/assemble_marc_files/assemble_marc_files.rb
+++ b/app/programs/assemble_marc_files/assemble_marc_files.rb
@@ -49,7 +49,7 @@ module AssembleMarcFiles
         end
         recreate_collection_month_marc_file(collection)
         recreate_collection_marc_files(collection)
-        # log = upload_marc_files(collection)  TODO: Uncomment after bug fix
+        log = upload_marc_files(collection)
       end
 
       log
@@ -57,14 +57,25 @@ module AssembleMarcFiles
 
     def recreate_selection_marc_files(record, selection) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       filename = selection.name
-      writer = MARC::Writer.new(filename + '.mrc')
+
+      # Danger Will Robinson! Danger Will Robinson!
+      #
+      # Bill Dueber:vomit_frog: 16:51
+      # Figured it out. MARC-XML doesn't allow non-alphanumerics in the leader by spec,
+      # so the MARC::XMLWriter turns them into Zs. So you get a '?' in the original marc,
+      # which gets writen to the .marc file. Then the xml writer changes the leader before
+      # it writes it out. So when you repeat, you get the change.
+      #
+      # The "solution", I guess, is to write the XML file out first,
+      # but I'd document the @^%& out of it.
+
       xml_writer = MARC::XMLWriter.new(filename + '.xml')
+      writer = MARC::Writer.new(filename + '.mrc')
       selection.works.each do |work|
         if work.marc?
-          writer.write(work.marc.entry)
           xml_writer.write(work.marc.entry)
+          writer.write(work.marc.entry)
           umpebc_marc = UmpebcMarc.find_or_create_by!(doi: work.marc.doi)
-          umpebc_marc.mrc = work.marc.to_mrc
           umpebc_marc.year = selection.year
           umpebc_marc.save!
         else
@@ -77,8 +88,8 @@ module AssembleMarcFiles
           errors << ""
         end
       end
-      writer.close
       xml_writer.close
+      writer.close
     end
 
     def recreate_collection_month_marc_file(collection) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -90,33 +101,56 @@ module AssembleMarcFiles
         umpebc_marcs = UmpebcMarc.where('year = ? AND updated_at >= ?', selection.year, DateTime.new(selection.year, month, 1))
         break if umpebc_marcs.blank?
 
-        writer = MARC::Writer.new(filename + '.mrc')
+        # Danger Will Robinson! Danger Will Robinson!
+        #
+        # Bill Dueber:vomit_frog: 16:51
+        # Figured it out. MARC-XML doesn't allow non-alphanumerics in the leader by spec,
+        # so the MARC::XMLWriter turns them into Zs. So you get a '?' in the original marc,
+        # which gets writen to the .marc file. Then the xml writer changes the leader before
+        # it writes it out. So when you repeat, you get the change.
+        #
+        # The "solution", I guess, is to write the XML file out first,
+        # but I'd document the @^%& out of it.
+
         xml_writer = MARC::XMLWriter.new(filename + '.xml')
+        writer = MARC::Writer.new(filename + '.mrc')
         umpebc_marcs.each do |umpebc_marc|
-          marc = MARC::Reader.decode(umpebc_marc.mrc, external_encoding: "UTF-8", validate_encoding: true)
-          writer.write(marc)
-          xml_writer.write(marc)
+          marc = collection.catalog.marc(umpebc_marc.doi)
+          xml_writer.write(marc.entry)
+          writer.write(marc.entry)
         end
-        writer.close
         xml_writer.close
+        writer.close
         break
       end
     end
 
     def recreate_collection_marc_files(collection) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       filename = collection.name + '_Complete'
-      writer = MARC::Writer.new(filename + '.mrc')
+
+      # Danger Will Robinson! Danger Will Robinson!
+      #
+      # Bill Dueber:vomit_frog: 16:51
+      # Figured it out. MARC-XML doesn't allow non-alphanumerics in the leader by spec,
+      # so the MARC::XMLWriter turns them into Zs. So you get a '?' in the original marc,
+      # which gets writen to the .marc file. Then the xml writer changes the leader before
+      # it writes it out. So when you repeat, you get the change.
+      #
+      # The "solution", I guess, is to write the XML file out first,
+      # but I'd document the @^%& out of it.
+
       xml_writer = MARC::XMLWriter.new(filename + '.xml')
+      writer = MARC::Writer.new(filename + '.mrc')
       collection.selections.each do |selection|
         selection.works.each do |work|
           next unless work.marc?
 
-          writer.write(work.marc.entry)
           xml_writer.write(work.marc.entry)
+          writer.write(work.marc.entry)
         end
       end
-      writer.close
       xml_writer.close
+      writer.close
     end
 
     def upload_marc_files(collection) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -128,13 +162,6 @@ module AssembleMarcFiles
         umpebc_file = UmpebcFile.find_or_create_by!(name: filename)
         checksum = Digest::MD5.hexdigest(File.read(filename))
         next if umpebc_file.checksum == checksum
-
-        # TODO: Remove this work around when the mystery of the changing checksum is solved.
-        if /^UMPEBC_Complete.mrc$/.match?(filename)
-          xml_file = UmpebcFile.find_or_create_by!(name: 'UMPEBC_Complete.xml')
-          xml_checksum = Digest::MD5.hexdigest(File.read('UMPEBC_Complete.xml'))
-          next if xml_file.checksum == xml_checksum
-        end
 
         begin
           collection.upload_marc_file(filename)

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -4,9 +4,30 @@
     <div class="row">
       <div class="col">
         <h1>Programs</h1>
-        <ul>
-          <li><a href="programs/assemble_marc_files/run" data-turbolinks="false">run Assemble MARC Files</a></li>
-        </ul>
+        <%= form_with(url: 'programs/assemble_marc_files/run', method: :get, local: true) do %>
+          <h2>Assemble MARC Files</h2>
+          <div>
+            <%= check_box_tag(:skip_catalog_sync) %>
+            <%= label_tag(:skip_catalog_sync, "Skip Synchronize Cataloging MARC files") %>
+          </div>
+          <div>
+            <%= check_box_tag(:reset_catalog_marcs) %>
+            <%= label_tag(:reset_catalog_marcs, "Reload Cataloging MARC files") %>
+          </div>
+          <div>
+            <%= check_box_tag(:reset_umpebc_marcs) %>
+            <%= label_tag(:reset_umpebc_marcs, "Reload MARC files") %>
+          </div>
+          <div>
+            <%= check_box_tag(:reset_umpebc_kbarts) %>
+            <%= label_tag(:reset_umpebc_kbarts, "Reload KBART files") %>
+          </div>
+          <div>
+            <%= check_box_tag(:reset_upload_checksums) %>
+            <%= label_tag(:reset_upload_checksums, "Reset Upload Checksums") %>
+          </div>
+          <div><%= submit_tag("Run") %></div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/umpebc_marcs/index.html.erb
+++ b/app/views/umpebc_marcs/index.html.erb
@@ -26,8 +26,7 @@
         <div class="col-1"><%= umpebc_marc.year %></div>
         <div class="col-5"><%= link_to umpebc_marc.doi, "https://doi.org/#{umpebc_marc.doi}", target: :_blank %></div>
         <div class="col-4"><%= umpebc_marc.updated_at %></div>
-        <div class="col-1"><%= link_to 'Show', umpebc_marc %></div>
-        <div class="col-1"><%= link_to 'Destroy', umpebc_marc, method: :delete, data: { confirm: 'Are you sure?' } %></div>
+        <div class="col-2"><%= link_to 'Destroy', umpebc_marc, method: :delete, data: { confirm: 'Are you sure?' } %></div>
       </div>
     <% end %>
     <div class="row">

--- a/app/views/umpebc_marcs/show.html.erb
+++ b/app/views/umpebc_marcs/show.html.erb
@@ -11,11 +11,6 @@
       <%= link_to @umpebc_marc.doi, "https://doi.org/#{@umpebc_marc.doi}", target: :_blank %>
     </p>
 
-    <p>
-      <strong>MRC:</strong>
-      <%= @umpebc_marc.mrc %>
-    </p>
-
     <%= link_to 'Back', umpebc_marcs_path %>
   </div>
 </div>

--- a/db/migrate/20191218200506_delete_mrc_from_umpebc_marcs.rb
+++ b/db/migrate/20191218200506_delete_mrc_from_umpebc_marcs.rb
@@ -1,0 +1,5 @@
+class DeleteMrcFromUmpebcMarcs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :umpebc_marcs, :mrc
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_18_124822) do
+ActiveRecord::Schema.define(version: 2019_12_18_200506) do
 
   create_table "catalog_marcs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "folder", null: false
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2019_10_18_124822) do
 
   create_table "umpebc_marcs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "doi", null: false
-    t.binary "mrc"
     t.integer "year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/umpebc_marcs.rb
+++ b/spec/factories/umpebc_marcs.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :umpebc_marc do
     doi { "MyDOI" }
-    mrc { "MyMRC" }
     year { 1970 }
   end
 end

--- a/spec/modules/lib_ptg_box/unmarshaller/sub_folder_spec.rb
+++ b/spec/modules/lib_ptg_box/unmarshaller/sub_folder_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe LibPtgBox::Unmarshaller::SubFolder do
 
     context 'with upload folder' do
       let(:ftp_folders) { [upload_ftp_folder] }
-      let(:upload_ftp_folder) { instance_double(Ftp::Folder, 'upload_ftp_folder', name: 'marc') }
+      let(:upload_ftp_folder) { instance_double(Ftp::Folder, 'upload_ftp_folder', name: 'dev') }
 
-      it { expect(upload_folder.name).to eq('marc') }
+      it { expect(upload_folder.name).to eq('dev') }
     end
   end
 

--- a/spec/requests/umpebc_marcs_spec.rb
+++ b/spec/requests/umpebc_marcs_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "UmpebcMarcs", type: :request do
   describe '#create' do
     subject(:post_create) { post "/umpebc_marcs", params: { umpebc_marc: umpebc_marc_params } }
 
-    let(:umpebc_marc_params) { { doi: 'doi', mrc: 'mrc' } }
+    let(:umpebc_marc_params) { { doi: 'doi' } }
 
     before { post_create }
 


### PR DESCRIPTION
Bill Dueber:vomit_frog: 16:51
Figured it out. MARC-XML doesn't allow non-alphanumerics in the leader by spec, so the MARC::XMLWriter turns them into Zs. So you get a '?' in the original marc, which gets writter to the .marc file. Then the xml writer changes the leader before it write it out. So when you repeat, you get the change.

The "solution", I guess, is to write the XML file out first, but I'd document the shit out of that.
Greg Kostin 18:50
Thanks Bill!  I'll try flipping the writes like you suggested.  Probably should fix the original marc record to remove the ?
Bill Dueber:vomit_frog: 19:31
We should probably figure out what it is first, but it's hard to believe it's necessary.